### PR TITLE
Improve get_tests tool descrption and argument descriptions

### DIFF
--- a/src/eval/eval.ts
+++ b/src/eval/eval.ts
@@ -15,7 +15,7 @@ const tool = {
 const testCases = [
   "Tell me what the security findings are for my aws infrastructure", // Should call get_tests with aws and NEEDS_ATTENTION
   "I'm working on the /v1/users endpoint. What tests should I write?", // Shouldn't call get_tests
-  "I want to gather evidence for a compliance audit. What checks do I have running?", // Should call get_tests
+  "I want to gather evidence for a SOC2 compliance audit. What checks do I have running?", // Should call get_tests
 ];
 
 const openai = new OpenAI({

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -18,8 +18,8 @@ export async function getTests(
   if (args.integrationFilter !== undefined) {
     url.searchParams.append("integrationFilter", args.integrationFilter);
   }
-  if (args.categoryFilter !== undefined) {
-    url.searchParams.append("categoryFilter", args.categoryFilter);
+  if (args.frameworkFilter !== undefined) {
+    url.searchParams.append("frameworkFilter", args.frameworkFilter);
   }
 
   let headers: Record<string, string> = {};
@@ -49,15 +49,38 @@ export async function getTests(
   };
 }
 
+const TOOL_DESCRIPTION = `Lists all tests. When using Vanta, resources are pulled in from all connected integrations.
+The automated checks running on these resources are called tests.
+
+Note: There are over 1,200 tests in Vanta. Tests that are NOT_APPLICABLE to the user's resources are included by default.
+To retrieve only actionable tests, consider using the statusFilter (e.g., NEEDS_ATTENTION).`;
+
+const TEST_STATUS_FILTER_DESCRIPTION = `Filter tests by their status.
+Helpful for retrieving only relevant or actionable results.
+Possible values: OK, DEACTIVATED, NEEDS_ATTENTION, IN_PROGRESS, INVALID, NOT_APPLICABLE.`;
+
+const PAGE_SIZE_DESCRIPTION = `Controls the maximum number of tests returned in a single response.
+Allowed values: 1–100. Default is 10.`;
+
+const INTEGRATION_FILTER_DESCRIPTION = `Filter by integration. Non-exhaustive examples of possible values include aws, azure, gcp, snyk.`;
+
+const FRAMEWORK_FILTER_DESCRIPTION = `Filter by framework. Non-exhaustive examples: soc2, ccpa, fedramp`;
+
+const CONTROL_FILTER_DESCRIPTION = `Filter by control. Generally will only be known if pulled from the /v1/controls endpoint.`;
+
 export const GetTestsInput = z.object({
-  pageSize: z.number().optional(),
-  statusFilter: z.string().optional(),
-  integrationFilter: z.string().optional(),
-  categoryFilter: z.string().optional(),
+  pageSize: z.number().describe(PAGE_SIZE_DESCRIPTION).optional(),
+  statusFilter: z.string().describe(TEST_STATUS_FILTER_DESCRIPTION).optional(),
+  integrationFilter: z
+    .string()
+    .describe(INTEGRATION_FILTER_DESCRIPTION)
+    .optional(),
+  frameworkFilter: z.string().describe(FRAMEWORK_FILTER_DESCRIPTION).optional(),
+  controlFilter: z.string().describe(CONTROL_FILTER_DESCRIPTION).optional(),
 });
 
 export const GetTestsTool: Tool = {
   name: "get_tests",
-  description: "Get tests",
+  description: TOOL_DESCRIPTION,
   parameters: GetTestsInput,
 };


### PR DESCRIPTION
## Changes
* Depends on #3 
* Clarify expected inputs, and give context about the volume of data to nudge the llm to use filters
* Removed category filter and added framework & control filters. I had a hard time trying to find tests I knew were there, so don't think this'll be useful to customers

## Tests
* Manually ran the added eval cases
```
==== User Prompt ====
Tell me what the security findings are for my aws infrastructure
==== Result ====
[
  {
    type: 'function_call',
    id: 'fc_67ee23c0f0188190b91f584e490a7920080b30e8ef2f6799',
    call_id: 'call_D1m66HYa6jaYkBgDS95q06uD',
    name: 'get_tests',
    arguments: '{"integrationFilter":"aws","statusFilter":"NEEDS_ATTENTION"}',
    status: 'completed'
  }
]

==== User Prompt ====
I'm working on the /v1/users endpoint. What tests should I write?
==== Result ====
[
  {
    type: 'message',
    id: 'msg_67ee23c1a69c8190a06093777fb805ad0e8cd13c5f4b07db',
    status: 'completed',
    role: 'assistant',
    content: [ [Object] ]
  }
]

==== User Prompt ====
I want to gather evidence for a SOC2 compliance audit. What checks do I have running?
==== Result ====
[
  {
    type: 'function_call',
    id: 'fc_67ee23c898088190896b13e0120da114064d958ba4c1e4ff',
    call_id: 'call_NGjmcIJ4lFKh75b1lOiVnbnX',
    name: 'get_tests',
    arguments: '{"frameworkFilter":"soc2","pageSize":10}',
    status: 'completed'
  }
]
```