### PR TITLE
Fixing Command Injection vulnerability

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,9 @@ jobs:
         
       - name: Update version if specified
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.version != ''
-        run: npm version ${{ github.event.inputs.version }} --no-git-tag-version
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+        run: npm version "$VERSION" --no-git-tag-version
         
       - name: Publish to NPM
         run: npm publish --access public


### PR DESCRIPTION
https://vanta-team-j1bu05uk.atlassian.net/browse/VM-4639

Fixing the Command Injection vulnerability in the publish workflow, where user can inject their own code into the input of the workflow.

The recommended approach is to process the input value as an environment variable and to double-quote it when using it