### PR TITLE
fix: pin zod to ^3.23.8 to prevent Zod 4.x installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.6.0",
-    "zod": ">= 3"
+    "zod": "^3.23.8",
+    "zod-to-json-schema": "^3.24.1"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
Zod 4.x introduces breaking API changes that cause tool calls to fail with: 'keyValidator._parse is not a function'

This pins zod and zod-to-json-schema to versions compatible with @modelcontextprotocol/sdk's expectations.

## Tested
Server starts successfully
Tool calls return data (no more keyValidator error)