### PR TITLE
Using trusted publishing mechanism to publish the package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,10 @@ on:
         required: false
         type: string
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+  
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -19,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           
       - name: Install dependencies
@@ -41,5 +45,3 @@ jobs:
         
       - name: Publish to NPM
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -82,11 +82,6 @@ A [Model Context Protocol](https://modelcontextprotocol.com/) server that provid
 | ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`vulnerabilities`](https://developer.vanta.com/reference/listvulnerabilities) | List vulnerabilities detected across your infrastructure or retrieve a specific vulnerability by ID with CVE details, severity, and impacted asset information. |
 
-### Multi-Region Support
-
-- US, EU, and AUS regions with region-specific API endpoints
-- Global compliance support for distributed organizations
-
 ## Tools
 
 | Tool Name                                                                                  | Description                                                                                                                                     |
@@ -162,7 +157,6 @@ Add the server to your Cursor MCP settings:
 ### Environment Variables
 
 - `VANTA_ENV_FILE` (required): Absolute path to the JSON file containing your OAuth credentials
-- `REGION` (optional): API region - `us`, `eu`, or `aus` (defaults to `us`)
 
 ## Installation
 


### PR DESCRIPTION
`NPM_TOKEN` recently expired and npm has recommended using the https://docs.npmjs.com/trusted-publishers mechanism for publishing rather than using a new access token.  I've added trusted publisher on npmjs.com.

I can't test the flow until I merge it in and run the action