### PR TITLE
Support VANTA_MCP_ENABLED_TOOLS env var for enabling additional tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ Add the server to your `claude_desktop_config.json`:
       "command": "npx",
       "args": ["-y", "@vantasdk/vanta-mcp-server"],
       "env": {
-        "VANTA_ENV_FILE": "/absolute/path/to/your/vanta-credentials.env"
+        "VANTA_ENV_FILE": "/absolute/path/to/your/vanta-credentials.env",
+        "VANTA_MCP_ENABLED_TOOLS": "vendors,list_discovered_vendors"
       }
     }
   }
@@ -147,7 +148,8 @@ Add the server to your Cursor MCP settings:
       "command": "npx",
       "args": ["-y", "@vantasdk/vanta-mcp-server"],
       "env": {
-        "VANTA_ENV_FILE": "/absolute/path/to/your/vanta-credentials.env"
+        "VANTA_ENV_FILE": "/absolute/path/to/your/vanta-credentials.env",
+        "VANTA_MCP_ENABLED_TOOLS": "vendors,list_discovered_vendors"
       }
     }
   }
@@ -157,6 +159,7 @@ Add the server to your Cursor MCP settings:
 ### Environment Variables
 
 - `VANTA_ENV_FILE` (required): Absolute path to the JSON file containing your OAuth credentials
+- `VANTA_MCP_ENABLED_TOOLS` (optional): Comma-separated list of additional tool names to enable beyond the defaults (e.g. `"vendors,list_discovered_vendors"`). Set to `*` to enable every tool.
 
 ## Installation
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,13 @@
 const normalizeName = (name: string): string => name.trim().toLowerCase();
 
-const enabledToolNames = [
-  // Add tool names here to restrict the server to a subset of tools.
-  // Leave the array empty to enable every tool.
-  // Example:
-  // "tests",
-  // "list_test_entities",
+const defaultToolNames = [
+  // Default set of tools enabled out of the box.
+  // To enable additional tools, set the VANTA_MCP_ENABLED_TOOLS environment
+  // variable to a comma-separated list of tool names (e.g.
+  // "vendors,list_discovered_vendors"). These are merged with the defaults.
+  //
+  // To enable every tool, set VANTA_MCP_ENABLED_TOOLS=* or leave this array
+  // empty and unset the environment variable.
   "tests",
   "list_test_entities",
   "people",
@@ -20,9 +22,26 @@ const enabledToolNames = [
   "frameworks",
   "list_framework_controls",
   "risks",
-].map(normalizeName);
+];
 
-export const enabledTools = new Set<string>(enabledToolNames);
+function resolveEnabledTools(): Set<string> {
+  const envValue = process.env.VANTA_MCP_ENABLED_TOOLS?.trim();
+
+  if (envValue === "*") {
+    // Wildcard: enable every tool
+    return new Set();
+  }
+
+  const names = [...defaultToolNames];
+
+  if (envValue) {
+    names.push(...envValue.split(","));
+  }
+
+  return new Set(names.map(normalizeName).filter(n => n.length > 0));
+}
+
+export const enabledTools = resolveEnabledTools();
 
 export const hasEnabledToolFilter = enabledTools.size > 0;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,9 +21,9 @@ async function main() {
 
     if (hasEnabledToolFilter) {
       const enabledTools = getEnabledToolNames();
-      console.error(
-        `⚠️ Tools enabled via VANTA_MCP_ENABLED_TOOLS: ${enabledTools.join(", ")}`,
-      );
+      console.error(`ℹ️ Enabled tools: ${enabledTools.join(", ")}`);
+    } else {
+      console.error("ℹ️ All tools enabled");
     }
 
     // Connect to stdio transport

--- a/src/operations/README.md
+++ b/src/operations/README.md
@@ -283,7 +283,7 @@ export default {
 4. **Extend the default export** with the new tool/handler pair.
 5. **Update `src/operations/index.ts`** to re-export the module (if a new file is added).
 6. **Document new tools** in `README.md` (root) and update evaluation artifacts (below).
-7. **Enable the tool in `src/config.ts`**. Add the tool's name to the `enabledToolNames` array to make it available through the MCP server. Leaving the array empty enables _all_ tools.
+7. **Enable the tool**. Either add the tool's name to the `defaultToolNames` array in `src/config.ts`, or instruct users to include it in the `VANTA_MCP_ENABLED_TOOLS` environment variable (comma-separated). Setting `VANTA_MCP_ENABLED_TOOLS=*` enables every tool.
 
 ## Evaluation Suite Updates
 


### PR DESCRIPTION
## Summary

- Adds support for the `VANTA_MCP_ENABLED_TOOLS` environment variable, allowing users to enable additional tools without modifying source code
- Tools specified in the env var (comma-separated) are merged with the hardcoded defaults; setting it to `*` enables every tool
- Fixes the existing log message in `index.ts` that already referenced this env var but was never wired up

## Motivation

Currently the only way to enable tools beyond the defaults (e.g. `vendors`) is to edit `src/config.ts` and rebuild. This change lets users configure enabled tools via their MCP client config:

```json
{
  "env": {
    "VANTA_MCP_ENABLED_TOOLS": "vendors,list_discovered_vendors"
  }
}
```

## Test plan

- [ ] Set `VANTA_MCP_ENABLED_TOOLS=vendors,list_discovered_vendors` → verify `vendors` tool is registered alongside defaults
- [ ] Set `VANTA_MCP_ENABLED_TOOLS=*` → verify all tools are registered
- [ ] Unset the env var → verify only hardcoded defaults are registered (no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)