### PR TITLE
Add missing filters to Vulnerabilities API and expose Vulnerable Assets

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@ const enabledToolNames = [
   "list_control_tests",
   "list_control_documents",
   "vulnerabilities",
+  "vulnerable_assets",
   "frameworks",
   "list_framework_controls",
   "risks",

--- a/src/operations/vulnerabilities.ts
+++ b/src/operations/vulnerabilities.ts
@@ -16,6 +16,12 @@ const VulnerabilitiesInput = createConsolidatedSchema(
     resourceName: "vulnerability",
   },
   {
+    q: z
+      .string()
+      .describe(
+        "Filter vulnerabilities by a search query, such as text appearing in vulnerability details.",
+      )
+      .optional(),
     externalVulnerabilityId: z
       .string()
       .describe(
@@ -23,27 +29,51 @@ const VulnerabilitiesInput = createConsolidatedSchema(
       )
       .optional(),
     severity: z
-      .string()
+      .enum(["LOW", "MEDIUM", "HIGH", "CRITICAL"])
       .describe(
-        "Filter vulnerabilities by severity. Possible values: LOW (Low severity), MEDIUM (Medium severity), HIGH (High severity), CRITICAL (Critical severity)",
+        "Filter vulnerabilities by severity. Possible values: LOW, MEDIUM, HIGH, CRITICAL.",
       )
       .optional(),
     integrationId: z
       .string()
       .describe(
-        "Filter vulnerabilities by integration ID. Returns vulnerabilities that are associated with the specified integration.",
+        "Filter vulnerabilities by integration ID. Returns vulnerabilities associated with the specified integration.",
       )
       .optional(),
-    slaDeadlineAfter: z
+    isDeactivated: z
+      .boolean()
+      .describe("Filter vulnerabilities by deactivation status.")
+      .optional(),
+    isFixAvailable: z
+      .boolean()
+      .describe("Filter vulnerabilities to only those which have an available fix.")
+      .optional(),
+    packageIdentifier: z
       .string()
       .describe(
-        "Filter vulnerabilities by SLA deadline after the specified date. Returns vulnerabilities that have an SLA deadline after the specified date. Date should be formatted as YYYY-MM-DD.",
+        "Filter vulnerabilities originating from a specific software package.",
       )
       .optional(),
-    slaDeadlineBefore: z
+    slaDeadlineAfterDate: z
       .string()
       .describe(
-        "Filter vulnerabilities by SLA deadline before the specified date. Returns vulnerabilities that have an SLA deadline before the specified date. Date should be formatted as YYYY-MM-DD.",
+        "Filter vulnerabilities with a 'remediate by' deadline after a specified timestamp (ISO 8601, e.g. 2024-01-01T00:00:00Z).",
+      )
+      .optional(),
+    slaDeadlineBeforeDate: z
+      .string()
+      .describe(
+        "Filter vulnerabilities that need to be remediated before a specific timestamp (ISO 8601, e.g. 2024-06-01T00:00:00Z).",
+      )
+      .optional(),
+    includeVulnerabilitiesWithoutSlas: z
+      .boolean()
+      .describe("Include vulnerabilities that lack a specified SLA due date.")
+      .optional(),
+    vulnerableAssetId: z
+      .string()
+      .describe(
+        "Filter vulnerabilities by the asset they affect, identified by a vulnerable asset ID.",
       )
       .optional(),
   },

--- a/src/operations/vulnerable-assets.ts
+++ b/src/operations/vulnerable-assets.ts
@@ -8,18 +8,49 @@ import {
 } from "./common/imports.js";
 
 // 2. Input Schemas
-const VulnerableAssetsInput = createConsolidatedSchema({
-  paramName: "vulnerableAssetId",
-  description:
-    "Vulnerable asset ID to retrieve, e.g. 'vulnerable-asset-123' or specific asset identifier",
-  resourceName: "vulnerable asset",
-});
+const VulnerableAssetsInput = createConsolidatedSchema(
+  {
+    paramName: "vulnerableAssetId",
+    description:
+      "Vulnerable asset ID to retrieve, e.g. 'vulnerable-asset-123' or specific asset identifier",
+    resourceName: "vulnerable asset",
+  },
+  {
+    q: z
+      .string()
+      .describe("Filter vulnerable assets by search query.")
+      .optional(),
+    integrationId: z
+      .string()
+      .describe("Filter vulnerable assets by specific vulnerability scanner.")
+      .optional(),
+    assetType: z
+      .enum([
+        "CODE_REPOSITORY",
+        "CONTAINER_REPOSITORY",
+        "CONTAINER_REPOSITORY_IMAGE",
+        "MANIFEST_FILE",
+        "SERVER",
+        "SERVERLESS_FUNCTION",
+        "WORKSTATION",
+        "OTHER",
+      ])
+      .describe(
+        "Narrow results by asset classification. Possible values: CODE_REPOSITORY, CONTAINER_REPOSITORY, CONTAINER_REPOSITORY_IMAGE, MANIFEST_FILE, SERVER, SERVERLESS_FUNCTION, WORKSTATION, OTHER.",
+      )
+      .optional(),
+    assetExternalAccountId: z
+      .string()
+      .describe("Filter vulnerable assets by external account identifier.")
+      .optional(),
+  },
+);
 
 // 3. Tool Definitions
 export const VulnerableAssetsTool: Tool<typeof VulnerableAssetsInput> = {
   name: "vulnerable_assets",
   description:
-    "Access vulnerable assets in your Vanta account. Provide vulnerableAssetId to get a specific vulnerable asset, or omit to list all vulnerable assets. Returns asset details, vulnerability counts, and security status.",
+    "Look up assets (servers, workstations, repositories, containers, etc.) in your Vanta account. Use this to resolve vulnerableAssetId values from vulnerability records into human-readable asset names and details. Provide vulnerableAssetId to get a specific asset, or omit to list all assets with optional filters. Returns asset name, type, external account, integration source, and associated vulnerability counts.",
   parameters: VulnerableAssetsInput,
 };
 


### PR DESCRIPTION
This allows the MCP server to use all filters available in the List Vulnerabilities api:

https://developer.vanta.com/reference/listvulnerabilities

It also adds direction to agents to dereference asset IDs to human readable names using the Vulnerable Asset api:

https://developer.vanta.com/reference/getvulnerableasset

This capability already existed but was not exposed in config.ts. This change adds to config.ts to expose that tool.