### PR TITLE
Add tool to deactivate monitoring for vulnerabilities and --dangerously-allow-writes flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,12 @@ A [Model Context Protocol](https://modelcontextprotocol.com/) server that provid
 ### Vulnerabilities
 
 - Review vulnerabilities surfaced by Vanta, including CVE metadata and affected assets
+- Deactivate vulnerability monitoring with a reason and optional expiry date *(requires `--dangerously-allow-writes`)*
 
-| Tool Name                                                                      | Description                                                                                                                                                     |
-| ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`vulnerabilities`](https://developer.vanta.com/reference/listvulnerabilities) | List vulnerabilities detected across your infrastructure or retrieve a specific vulnerability by ID with CVE details, severity, and impacted asset information. |
+| Tool Name                                                                                    | Description                                                                                                                                                     |
+| -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`vulnerabilities`](https://developer.vanta.com/reference/listvulnerabilities)               | List vulnerabilities detected across your infrastructure or retrieve a specific vulnerability by ID with CVE details, severity, and impacted asset information. |
+| [`deactivate_vulnerabilities`](https://developer.vanta.com/reference/deactivatevulnerabilities) ⚠️ | Deactivate monitoring for 1–50 vulnerabilities. Requires a reason per entry and a flag controlling auto-reactivation when a fix becomes available. Optionally set an expiry date. **Requires `--dangerously-allow-writes`**. |
 
 ## Tools
 
@@ -100,6 +102,7 @@ A [Model Context Protocol](https://modelcontextprotocol.com/) server that provid
 | [`people`](https://developer.vanta.com/reference/listpeople)                               | List people across your organization or look up a specific person by ID with role, email, and group membership metadata.                        |
 | [`risks`](https://developer.vanta.com/reference/listriskscenarios)                         | List risk scenarios under management or fetch a specific scenario to review status, scoring, and treatment plans.                               |
 | [`vulnerabilities`](https://developer.vanta.com/reference/listvulnerabilities)             | List detected vulnerabilities or retrieve a specific item with CVE metadata, severity, and impacted assets.                                     |
+| [`deactivate_vulnerabilities`](https://developer.vanta.com/reference/deactivatevulnerabilities) ⚠️ | Deactivate monitoring for 1–50 vulnerabilities. Requires `--dangerously-allow-writes`. |
 
 ## Configuration
 
@@ -146,6 +149,47 @@ Add the server to your Cursor MCP settings:
     "Vanta": {
       "command": "npx",
       "args": ["-y", "@vantasdk/vanta-mcp-server"],
+      "env": {
+        "VANTA_ENV_FILE": "/absolute/path/to/your/vanta-credentials.env"
+      }
+    }
+  }
+}
+```
+
+### Write Operations
+
+By default the server is read-only. To enable write tools, pass `--dangerously-allow-writes` when starting the server. This flag:
+
+- Registers write tools (e.g. `deactivate_vulnerabilities`) that are otherwise hidden
+- Requests the `vanta-api.all:write` OAuth scope in addition to `vanta-api.all:read`
+
+> **⚠️ Warning:** Write operations modify data in your Vanta account. Only enable this flag in environments and with credentials where mutations are intended.
+
+To enable in **Claude Desktop**, add the flag to the `args` array:
+
+```json
+{
+  "mcpServers": {
+    "vanta": {
+      "command": "npx",
+      "args": ["-y", "@vantasdk/vanta-mcp-server", "--dangerously-allow-writes"],
+      "env": {
+        "VANTA_ENV_FILE": "/absolute/path/to/your/vanta-credentials.env"
+      }
+    }
+  }
+}
+```
+
+To enable in **Cursor**, add the flag to the `args` array:
+
+```json
+{
+  "mcpServers": {
+    "Vanta": {
+      "command": "npx",
+      "args": ["-y", "@vantasdk/vanta-mcp-server", "--dangerously-allow-writes"],
       "env": {
         "VANTA_ENV_FILE": "/absolute/path/to/your/vanta-credentials.env"
       }
@@ -227,34 +271,35 @@ This server is built with TypeScript and includes the following development tool
 ```
 vanta-mcp-server/
 ├── src/
-│   ├── operations/              # MCP tool implementations
-│   │   ├── index.ts            # Barrel export for all operations
-│   │   ├── common/             # Shared utilities and infrastructure
-│   │   │   ├── descriptions.ts # Centralized parameter descriptions
-│   │   │   ├── imports.ts      # Common imports barrel for operations
-│   │   │   └── utils.ts        # DRY utilities and request handlers
-│   │   ├── controls.ts         # Control-related operations
-│   │   ├── vendors.ts          # Vendor-related operations
-│   │   ├── people.ts           # People-related operations
-│   │   ├── documents.ts        # Document-related operations
-│   │   ├── frameworks.ts       # Framework-related operations
-│   │   ├── risks.ts            # Risk scenario operations
-│   │   ├── tests.ts            # Test-related operations
-│   │   ├── integrations.ts     # Integration-related operations (consolidated)
-│   │   ├── discovered-vendors.ts # Discovery operations (consolidated)
-│   │   ├── trust-centers.ts    # Trust Center operations
-│   │   └── ...                 # Other resource operations (18 total)
-│   ├── eval/                   # Evaluation and testing framework
-│   │   ├── eval.ts            # LLM evaluation test cases
-│   │   └── README.md          # Evaluation documentation
-│   ├── api.ts                  # Base API configuration
-│   ├── auth.ts                 # Authentication handling
-│   ├── config.ts               # Control enabled tools
-│   ├── index.ts                # Main server entry point
-│   ├── registry.ts             # Automated tool registration
-│   └── types.ts                # Type definitions
-├── build/                      # Compiled JavaScript output
-└── README.md                   # This file
+│   ├── operations/                  # MCP tool implementations
+│   │   ├── index.ts                 # Barrel export for all operations
+│   │   ├── common/                  # Shared utilities and infrastructure
+│   │   │   ├── descriptions.ts      # Centralized parameter descriptions
+│   │   │   ├── imports.ts           # Common imports barrel for operations
+│   │   │   └── utils.ts             # DRY utilities and request handlers
+│   │   ├── controls.ts              # Control-related operations
+│   │   ├── vendors.ts               # Vendor-related operations
+│   │   ├── people.ts                # People-related operations
+│   │   ├── documents.ts             # Document-related operations
+│   │   ├── frameworks.ts            # Framework-related operations
+│   │   ├── risks.ts                 # Risk scenario operations
+│   │   ├── tests.ts                 # Test-related operations
+│   │   ├── integrations.ts          # Integration-related operations (consolidated)
+│   │   ├── discovered-vendors.ts    # Discovery operations (consolidated)
+│   │   ├── trust-centers.ts         # Trust Center operations
+│   │   ├── write-vulnerabilities.ts # Write operations for vulnerabilities (requires --dangerously-allow-writes)
+│   │   └── ...                      # Other resource operations (18 total)
+│   ├── eval/                        # Evaluation and testing framework
+│   │   ├── eval.ts                  # LLM evaluation test cases
+│   │   └── README.md                # Evaluation documentation
+│   ├── api.ts                       # Base API configuration
+│   ├── auth.ts                      # Authentication handling
+│   ├── config.ts                    # Control enabled tools
+│   ├── index.ts                     # Main server entry point
+│   ├── registry.ts                  # Automated tool registration
+│   └── types.ts                     # Type definitions
+├── build/                           # Compiled JavaScript output
+└── README.md                        # This file
 ```
 
 ### Architecture Highlights

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -64,6 +64,7 @@ function loadCredentials(): OAuthCredentials {
 async function fetchNewToken(): Promise<TokenInfo> {
   const credentials = loadCredentials();
 
+  // nosemgrep: use-request-fetcher — URL is the compile-time constant BASE_API_URL; RequestFetcher is not available in this repo
   const response = await fetch(`${BASE_API_URL}/oauth/token`, {
     method: "POST",
     headers: {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,8 +1,13 @@
 import fs from "node:fs";
 import { BASE_API_URL } from "./api.js";
 import { z } from "zod";
+import { isWritesEnabled } from "./config.js";
 
-const VANTA_API_SCOPE = "vanta-api.all:read";
+function getApiScope(): string {
+  return isWritesEnabled()
+    ? "vanta-api.all:read vanta-api.all:write"
+    : "vanta-api.all:read";
+}
 
 interface OAuthCredentials {
   client_id: string;
@@ -68,7 +73,7 @@ async function fetchNewToken(): Promise<TokenInfo> {
       client_id: credentials.client_id,
       client_secret: credentials.client_secret,
       grant_type: "client_credentials",
-      scope: VANTA_API_SCOPE,
+      scope: getApiScope(),
     }),
   });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,11 @@
 const normalizeName = (name: string): string => name.trim().toLowerCase();
 
+let writesEnabled = false;
+export const setWritesEnabled = (val: boolean): void => {
+  writesEnabled = val;
+};
+export const isWritesEnabled = (): boolean => writesEnabled;
+
 const enabledToolNames = [
   // Add tool names here to restrict the server to a subset of tools.
   // Leave the array empty to enable every tool.
@@ -20,6 +26,7 @@ const enabledToolNames = [
   "frameworks",
   "list_framework_controls",
   "risks",
+  "deactivate_vulnerabilities",
 ].map(normalizeName);
 
 export const enabledTools = new Set<string>(enabledToolNames);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,13 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerAllOperations } from "./registry.js";
 import { initializeToken } from "./auth.js";
-import { getEnabledToolNames, hasEnabledToolFilter } from "./config.js";
+import {
+  getEnabledToolNames,
+  hasEnabledToolFilter,
+  setWritesEnabled,
+} from "./config.js";
+
+const dangerouslyAllowWrites = process.argv.includes("--dangerously-allow-writes");
 
 const server = new McpServer({
   name: "vanta-mcp",
@@ -13,11 +19,16 @@ const server = new McpServer({
 
 async function main() {
   try {
+    setWritesEnabled(dangerouslyAllowWrites);
     await initializeToken();
     console.error("Token initialized successfully");
 
     // Register all tools automatically
     await registerAllOperations(server);
+
+    if (dangerouslyAllowWrites) {
+      console.error("⚠️  Write operations ENABLED (--dangerously-allow-writes)");
+    }
 
     if (hasEnabledToolFilter) {
       const enabledTools = getEnabledToolNames();

--- a/src/operations/common/utils.ts
+++ b/src/operations/common/utils.ts
@@ -58,6 +58,21 @@ export async function makeAuthenticatedRequest(
   return response;
 }
 
+/**
+ * Makes an authenticated HTTP write request (POST, PATCH, or DELETE) with a JSON body.
+ */
+export async function makeAuthenticatedWriteRequest(
+  url: string,
+  method: "POST" | "PATCH" | "DELETE",
+  body?: unknown,
+): Promise<Response> {
+  return makeAuthenticatedRequest(url, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
 // ==========================================
 // RESPONSE PROCESSING UTILITIES
 // ==========================================

--- a/src/operations/write-vulnerabilities.ts
+++ b/src/operations/write-vulnerabilities.ts
@@ -1,0 +1,67 @@
+// 1. Imports
+import {
+  CallToolResult,
+  Tool,
+  z,
+  buildUrl,
+  makeAuthenticatedWriteRequest,
+  handleApiResponse,
+} from "./common/imports.js";
+
+// 2. Input Schemas
+const DeactivateVulnerabilityUpdateSchema = z.object({
+  id: z.string().describe("ID of the vulnerability to deactivate."),
+  deactivateReason: z
+    .string()
+    .min(1)
+    .describe("Justification for deactivating this vulnerability."),
+  shouldReactivateWhenFixable: z
+    .boolean()
+    .describe(
+      "Whether the vulnerability should automatically reactivate when a fix becomes available.",
+    ),
+  deactivateUntilDate: z
+    .string()
+    .describe(
+      "Optional ISO 8601 datetime after which the vulnerability will reactivate, e.g. '2025-12-31T00:00:00Z'.",
+    )
+    .optional(),
+});
+
+const DeactivateVulnerabilitiesInput = z.object({
+  updates: z
+    .array(DeactivateVulnerabilityUpdateSchema)
+    .min(1)
+    .max(50)
+    .describe("List of vulnerabilities to deactivate (1–50 items)."),
+});
+
+// 3. Tool Definitions
+export const DeactivateVulnerabilitiesTool: Tool<
+  typeof DeactivateVulnerabilitiesInput
+> = {
+  name: "deactivate_vulnerabilities",
+  description:
+    "Deactivate monitoring for one or more vulnerabilities. Each entry requires a reason and a flag controlling whether it auto-reactivates when a fix is available. Optionally set an expiry date after which monitoring resumes. Accepts 1–50 vulnerabilities per call.",
+  parameters: DeactivateVulnerabilitiesInput,
+};
+
+// 4. Implementation Functions
+export async function deactivateVulnerabilities(
+  args: z.infer<typeof DeactivateVulnerabilitiesInput>,
+): Promise<CallToolResult> {
+  const url = buildUrl("/v1/vulnerabilities/deactivate");
+  const response = await makeAuthenticatedWriteRequest(url, "POST", args);
+  return handleApiResponse(response);
+}
+
+// Registry export — requiresWrites gates this tool behind --dangerously-allow-writes
+export default {
+  tools: [
+    {
+      tool: DeactivateVulnerabilitiesTool,
+      handler: deactivateVulnerabilities,
+      requiresWrites: true,
+    },
+  ],
+};

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -5,6 +5,7 @@ import {
   getEnabledToolNames,
   hasEnabledToolFilter,
   isToolEnabled,
+  isWritesEnabled,
 } from "./config.js";
 
 // Tool definition interface (matches our Tool pattern)
@@ -18,6 +19,7 @@ export interface ToolDefinition {
 export interface ToolEntry {
   tool: ToolDefinition;
   handler: (args: z.infer<z.ZodTypeAny>) => Promise<CallToolResult>;
+  requiresWrites?: boolean;
 }
 
 export interface OperationModule {
@@ -29,7 +31,13 @@ export function registerTool(
   server: McpServer,
   tool: ToolDefinition,
   handler: (args: z.infer<z.ZodTypeAny>) => Promise<CallToolResult>,
+  entry: Pick<ToolEntry, "requiresWrites"> = {},
 ): boolean {
+  if (entry.requiresWrites && !isWritesEnabled()) {
+    console.error(`🔒 Skipping write tool (--dangerously-allow-writes not set): ${tool.name}`);
+    return false;
+  }
+
   if (!isToolEnabled(tool.name)) {
     console.error(`⚪️ Skipping tool not in enabled list: ${tool.name}`);
     return false;
@@ -48,8 +56,8 @@ export function registerOperationModule(
   let registered = 0;
   let skipped = 0;
 
-  operationModule.tools.forEach(({ tool, handler }) => {
-    const wasRegistered = registerTool(server, tool, handler);
+  operationModule.tools.forEach(({ tool, handler, requiresWrites }) => {
+    const wasRegistered = registerTool(server, tool, handler, { requiresWrites });
     if (wasRegistered) {
       registered += 1;
     } else {
@@ -81,6 +89,7 @@ export async function registerAllOperations(server: McpServer): Promise<void> {
     import("./operations/monitored-computers.js"),
     import("./operations/vendor-risk-attributes.js"),
     import("./operations/trust-centers.js"),
+    import("./operations/write-vulnerabilities.js"),
   ];
 
   // Load all modules and register their tools


### PR DESCRIPTION
This adds a `deactivate_vulnerabilities` tool to the MCP server to allow agents to deactivate monitoring on vulnerabilities. This helps users build agents that can act on their vulnerabilities as well as report on them.

To preserve the existing read only behavior of the MCP server I put the `deactivate_vulnerabilities` tool behind a CLI flag `--dangerously-allow-writes`. This is a reusable facility for future tools that need to write to Vanta. If a tool indicates that write access is required and the user does not run the MCP server with `--dangerously-allow-writes` the tools requesting write access are not loaded.

EG: To enable, add the flag to the MCP client config:

```
"args": ["-y", "@vantasdk/vanta-mcp-server", "--dangerously-allow-writes"]
```